### PR TITLE
feat: use in-memory MassTransit for integration event publishing

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,6 +20,7 @@
   - Reliable event processing with transactional consistency
   - Publish with MediatR in a background service
   - Automatic retries for failed events
+- Uses in-memory **MassTransit** to publish **integration events**
 - **FusionCache (Hybrid Caching)**
   - Stores cached items in both distributed cache (Redis) and memory cache.
   - Retrieves project settings using a hybrid cache mechanism. 

--- a/src/ShelfApi.Application/ProductApplication/EventHandlers/ProductIntegrationEventHandler.cs
+++ b/src/ShelfApi.Application/ProductApplication/EventHandlers/ProductIntegrationEventHandler.cs
@@ -1,0 +1,32 @@
+using MassTransit;
+using Microsoft.Extensions.Logging;
+using ShelfApi.Domain.ProductAggregate.Events;
+
+namespace ShelfApi.Application.ProductApplication.EventHandlers;
+
+public class ProductIntegrationEventHandler(ILogger<ProductIntegrationEventHandler> logger)
+    : IConsumer<ProductCreatedDomainEvent>,
+        IConsumer<ProductUpdatedDomainEvent>,
+        IConsumer<ProductDeletedDomainEvent>
+{
+    public Task Consume(ConsumeContext<ProductCreatedDomainEvent> context)
+    {
+        ProductCreatedDomainEvent @event = context.Message;
+        logger.LogInformation("MassTransit consumed ProductCreatedDomainEvent: {@event}", @event);
+        return Task.CompletedTask;
+    }
+
+    public Task Consume(ConsumeContext<ProductUpdatedDomainEvent> context)
+    {
+        ProductUpdatedDomainEvent @event = context.Message;
+        logger.LogInformation("MassTransit consumed ProductUpdatedDomainEvent: {@event}", @event);
+        return Task.CompletedTask;
+    }
+
+    public Task Consume(ConsumeContext<ProductDeletedDomainEvent> context)
+    {
+        ProductDeletedDomainEvent @event = context.Message;
+        logger.LogInformation("MassTransit consumed ProductDeletedDomainEvent: {@event}", @event);
+        return Task.CompletedTask;
+    }
+}

--- a/src/ShelfApi.Application/ShelfApi.Application.csproj
+++ b/src/ShelfApi.Application/ShelfApi.Application.csproj
@@ -8,6 +8,7 @@
 
     <ItemGroup>
         <PackageReference Include="EFCore.BulkExtensions" Version="8.0.4"/>
+        <PackageReference Include="MassTransit.Abstractions" Version="8.4.1"/>
         <PackageReference Include="MediatR" Version="12.3.0"/>
         <PackageReference Include="Microsoft.AspNetCore.Identity" Version="2.2.0"/>
         <PackageReference Include="Microsoft.EntityFrameworkCore" Version="8.0.6"/>

--- a/src/ShelfApi.Domain/Common/Interfaces/IIntegrationEvent.cs
+++ b/src/ShelfApi.Domain/Common/Interfaces/IIntegrationEvent.cs
@@ -1,0 +1,6 @@
+namespace ShelfApi.Domain.Common.Interfaces;
+
+// Integration events that should be published to the message bus
+public interface IIntegrationEvent
+{
+}

--- a/src/ShelfApi.Domain/ProductAggregate/Events/ProductDomainEvent.cs
+++ b/src/ShelfApi.Domain/ProductAggregate/Events/ProductDomainEvent.cs
@@ -2,7 +2,7 @@ using ShelfApi.Domain.Common.Interfaces;
 
 namespace ShelfApi.Domain.ProductAggregate.Events;
 
-public abstract record ProductDomainEvent : IDomainEvent
+public abstract record ProductDomainEvent : IDomainEvent, IIntegrationEvent
 {
     private readonly Product _product;
 

--- a/src/ShelfApi.Infrastructure/ShelfApi.Infrastructure.csproj
+++ b/src/ShelfApi.Infrastructure/ShelfApi.Infrastructure.csproj
@@ -10,6 +10,7 @@
         <PackageReference Include="Elastic.Clients.Elasticsearch" Version="8.17.3"/>
         <PackageReference Include="Elastic.Serilog.Sinks" Version="8.12.3"/>
         <PackageReference Include="IdGen" Version="3.0.7"/>
+        <PackageReference Include="MassTransit" Version="8.4.1"/>
         <PackageReference Include="Microsoft.AspNetCore.Identity.EntityFrameworkCore" Version="8.0.6"/>
         <PackageReference Include="Microsoft.EntityFrameworkCore" Version="8.0.6"/>
         <PackageReference Include="Microsoft.EntityFrameworkCore.Design" Version="8.0.6">


### PR DESCRIPTION
- Introduced IIntegrationEvent interface to standardize domain events that require external publishing.

- Added ProductIntegrationEventHandler to consume integration events of ProductCreated, ProductUpdated, and ProductDeleted.

- Configured MassTransit with in-memory transport for lightweight, local event dispatching.