### PR TITLE
feat: migrate MassTransit from in-memory to RabbitMQ for integration events

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,7 +20,7 @@
   - Reliable event processing with transactional consistency
   - Publish with MediatR in a background service
   - Automatic retries for failed events
-- Uses in-memory **MassTransit** to publish **integration events**
+- Uses **RabbitMQ** with **MassTransit** to publish **integration events**
 - **FusionCache (Hybrid Caching)**
   - Stores cached items in both distributed cache (Redis) and memory cache.
   - Retrieves project settings using a hybrid cache mechanism. 

--- a/docker/rabbitmq/docker-compose.yml
+++ b/docker/rabbitmq/docker-compose.yml
@@ -1,0 +1,29 @@
+version: '3.9'
+
+services:
+  rabbitmq:
+    image: rabbitmq:4.1-management
+    container_name: rabbitmq
+    hostname: rabbitmq
+    ports:
+      - "5673:5672" # AMQP port
+      - "15673:15672" # Management UI port
+    environment:
+      - RABBITMQ_DEFAULT_USER=guest
+      - RABBITMQ_DEFAULT_PASS=guest
+      - RABBITMQ_LOGS=-
+    volumes:
+      - ./data:/var/lib/rabbitmq
+      - ./logs:/var/log/rabbitmq
+    restart: always
+    networks:
+      - app-network
+    healthcheck:
+      test: ["CMD", "rabbitmqctl", "status"]
+      interval: 30s
+      timeout: 10s
+      retries: 5
+
+networks:
+  app-network:
+    driver: bridge

--- a/src/ShelfApi.Application/Common/Data/StartupData.cs
+++ b/src/ShelfApi.Application/Common/Data/StartupData.cs
@@ -30,6 +30,14 @@ public record StartupData
             {
                 [nameof(ProductElasticDocument).ToCamelCase()] = "products"
             }
+        },
+        RabbitMq = new()
+        {
+            Host = "localhost",
+            Port = 5672,
+            VirtualHost = "/",
+            Username = "guest",
+            Password = "guest"
         }
     };
 
@@ -37,6 +45,7 @@ public record StartupData
     public JwtStartupData Jwt { get; init; }
     public RedisStartupData Redis { get; init; }
     public ElasticsearchStartupData Elasticsearch { get; init; }
+    public RabbitMqStartupData RabbitMq { get; init; }
 }
 
 public record JwtStartupData
@@ -68,4 +77,13 @@ public record ElasticsearchStartupData
         get => _indexNames;
         init => _indexNames = new(value, StringComparer.OrdinalIgnoreCase);
     }
+}
+
+public record RabbitMqStartupData
+{
+    public string Host { get; init; }
+    public ushort Port { get; init; }
+    public string VirtualHost { get; init; }
+    public string Username { get; init; }
+    public string Password { get; init; }
 }

--- a/src/ShelfApi.Infrastructure/ServiceInjector.cs
+++ b/src/ShelfApi.Infrastructure/ServiceInjector.cs
@@ -33,7 +33,7 @@ public static class ServiceInjector
         services.AddShelfApiDbContext(startupData);
         services.AddFusionCache(startupData);
         services.AddElasticsearch(startupData);
-        services.AddMassTransit();
+        services.AddMassTransit(startupData);
 
         services.AddSingleton<IIdManager, IdManager>();
     }
@@ -149,12 +149,19 @@ public static class ServiceInjector
         services.AddElasticsearch(elasticsearchSettings);
     }
 
-    private static void AddMassTransit(this IServiceCollection services)
+    private static void AddMassTransit(this IServiceCollection services, StartupData startupData)
     {
         services.AddMassTransit(configure =>
         {
-            configure.UsingInMemory((context, cfg) =>
+            configure.UsingRabbitMq((context, cfg) =>
             {
+                cfg.Host(startupData.RabbitMq.Host, startupData.RabbitMq.Port,
+                    startupData.RabbitMq.VirtualHost, h =>
+                    {
+                        h.Username(startupData.RabbitMq.Username);
+                        h.Password(startupData.RabbitMq.Password);
+                    });
+
                 cfg.ConfigureEndpoints(context);
             });
 

--- a/src/ShelfApi.Infrastructure/ShelfApi.Infrastructure.csproj
+++ b/src/ShelfApi.Infrastructure/ShelfApi.Infrastructure.csproj
@@ -11,6 +11,7 @@
         <PackageReference Include="Elastic.Serilog.Sinks" Version="8.12.3"/>
         <PackageReference Include="IdGen" Version="3.0.7"/>
         <PackageReference Include="MassTransit" Version="8.4.1"/>
+        <PackageReference Include="MassTransit.RabbitMQ" Version="8.4.1"/>
         <PackageReference Include="Microsoft.AspNetCore.Identity.EntityFrameworkCore" Version="8.0.6"/>
         <PackageReference Include="Microsoft.EntityFrameworkCore" Version="8.0.6"/>
         <PackageReference Include="Microsoft.EntityFrameworkCore.Design" Version="8.0.6">

--- a/src/ShelfApi.Presentation/Controllers/AAAController.cs
+++ b/src/ShelfApi.Presentation/Controllers/AAAController.cs
@@ -1,0 +1,19 @@
+using DotNetPotion.AppEnvironmentPack;
+using Microsoft.AspNetCore.Mvc;
+
+namespace ShelfApi.Presentation.Controllers;
+
+[ApiController]
+[Route("api/[controller]")]
+public class AAAController : ControllerBase
+{
+    [HttpPost("test")]
+    public async Task<IActionResult> TestAsync([FromBody] int a1)
+    {
+        if (!AppEnvironment.IsDevelopment)
+            return NotFound();
+
+        await Task.CompletedTask;
+        return Ok();
+    }
+}


### PR DESCRIPTION
Replace in-memory implementation with RabbitMQ for publishing integration events via MassTransit, providing more robust messaging infrastructure for distributed communication.